### PR TITLE
Add skeletal ASE-RSL-RL framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AMP-RSL-RL is a reinforcement learning library that extends the Proximal Policy Optimization (PPO) implementation of [RSL-RL](https://github.com/leggedrobotics/rsl_rl) to incorporate Adversarial Motion Priors (AMP). This framework enables humanoid agents to learn motor skills from motion capture data using adversarial imitation learning techniques.
 
+The repository also provides a **preliminary framework for Adversarial Skill Embeddings (ASE)** built on top of RSL-RL. The ASE components are located under the `ase_rsl_rl` package and offer an extensible scaffold for skill-conditioned policies and discriminators.
+
 ---
 
 ## 📦 Installation
@@ -58,6 +60,13 @@ amp_rsl_rl/
 ├── runners/           # Training and evaluation routines
 ├── storage/           # Replay buffer for experience collection
 ├── utils/             # Dataset loaders and motion tools
+
+ase_rsl_rl/
+│
+├── algorithms/        # ASE extensions of PPO
+├── networks/          # Skill-conditioned discriminators
+├── storage/           # Replay buffer placeholders for ASE
+└── utils/             # Minimal ASE dataset utilities
 ```
 
 ---

--- a/ase_rsl_rl/__init__.py
+++ b/ase_rsl_rl/__init__.py
@@ -1,0 +1,1 @@
+"""Main module for the ase_rsl_rl package."""

--- a/ase_rsl_rl/algorithms/__init__.py
+++ b/ase_rsl_rl/algorithms/__init__.py
@@ -1,0 +1,5 @@
+"""Algorithms combining ASE with RSL-RL."""
+
+from .ase_ppo import ASE_PPO
+
+__all__ = ["ASE_PPO"]

--- a/ase_rsl_rl/algorithms/ase_ppo.py
+++ b/ase_rsl_rl/algorithms/ase_ppo.py
@@ -1,0 +1,73 @@
+"""ASE integrated with PPO for the RSL-RL framework."""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+import torch
+
+from amp_rsl_rl.algorithms.amp_ppo import AMP_PPO
+from ase_rsl_rl.networks import SkillDiscriminator
+from ase_rsl_rl.storage import SkillReplayBuffer
+from ase_rsl_rl.utils import ASELoader
+
+
+class ASE_PPO(AMP_PPO):
+    """PPO algorithm augmented with Adversarial Skill Embeddings.
+
+    This class inherits from :class:`amp_rsl_rl.algorithms.AMP_PPO` and
+    exposes an interface for skill-conditioned policies.  The current
+    implementation mirrors the behaviour of ``AMP_PPO`` and acts as a
+    scaffold for future ASE-specific logic.
+    """
+
+    def __init__(
+        self,
+        actor_critic,
+        discriminator: SkillDiscriminator,
+        ase_data: ASELoader,
+        ase_normalizer: Optional[Any],
+        skill_dim: int,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            actor_critic=actor_critic,
+            discriminator=discriminator,
+            amp_data=ase_data,
+            amp_normalizer=ase_normalizer,
+            **kwargs,
+        )
+        self.skill_dim = skill_dim
+
+    def init_storage(
+        self,
+        num_envs: int,
+        num_transitions_per_env: int,
+        actor_obs_shape: Tuple[int, ...],
+        critic_obs_shape: Tuple[int, ...],
+        action_shape: Tuple[int, ...],
+        skill_shape: Tuple[int, ...],
+    ) -> None:
+        """Initialises rollout storage and reserves space for skill latents."""
+        super().init_storage(
+            num_envs=num_envs,
+            num_transitions_per_env=num_transitions_per_env,
+            actor_obs_shape=actor_obs_shape,
+            critic_obs_shape=critic_obs_shape,
+            action_shape=action_shape,
+        )
+        assert self.storage is not None
+        self.storage.extras = {
+            "skills": torch.zeros(
+                (num_transitions_per_env, num_envs, *skill_shape), device=self.device
+            )
+        }
+
+    def act(
+        self, obs: torch.Tensor, critic_obs: torch.Tensor, skill: torch.Tensor
+    ) -> torch.Tensor:
+        """Selects actions conditioned on the provided skill embedding.
+
+        The default behaviour simply forwards to ``AMP_PPO.act``.
+        """
+        return super().act(obs, critic_obs)

--- a/ase_rsl_rl/networks/__init__.py
+++ b/ase_rsl_rl/networks/__init__.py
@@ -1,0 +1,5 @@
+"""Networks used by ASE-RSL-RL."""
+
+from .skill_discriminator import SkillDiscriminator
+
+__all__ = ["SkillDiscriminator"]

--- a/ase_rsl_rl/networks/skill_discriminator.py
+++ b/ase_rsl_rl/networks/skill_discriminator.py
@@ -1,0 +1,14 @@
+"""Skill-aware discriminator for ASE."""
+
+from amp_rsl_rl.networks import Discriminator
+
+
+class SkillDiscriminator(Discriminator):
+    """Discriminator tailored for Adversarial Skill Embeddings.
+
+    This class currently inherits all functionality from
+    :class:`amp_rsl_rl.networks.Discriminator` but is provided as a
+    dedicated entry point for ASE-specific extensions.
+    """
+
+    pass

--- a/ase_rsl_rl/storage/__init__.py
+++ b/ase_rsl_rl/storage/__init__.py
@@ -1,0 +1,5 @@
+"""Storage utilities for ASE-RSL-RL."""
+
+from .skill_replay_buffer import SkillReplayBuffer
+
+__all__ = ["SkillReplayBuffer"]

--- a/ase_rsl_rl/storage/skill_replay_buffer.py
+++ b/ase_rsl_rl/storage/skill_replay_buffer.py
@@ -1,0 +1,14 @@
+"""Replay buffer storing transitions augmented with skill embeddings."""
+
+from amp_rsl_rl.storage import ReplayBuffer
+
+
+class SkillReplayBuffer(ReplayBuffer):
+    """Replay buffer used by ASE to cache policy transitions.
+
+    The implementation currently mirrors
+    :class:`amp_rsl_rl.storage.ReplayBuffer` and acts as a placeholder
+    for potential ASE-specific extensions.
+    """
+
+    pass

--- a/ase_rsl_rl/utils/__init__.py
+++ b/ase_rsl_rl/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utilities for ASE-RSL-RL."""
+
+from .loader import ASELoader
+
+__all__ = ["ASELoader"]

--- a/ase_rsl_rl/utils/loader.py
+++ b/ase_rsl_rl/utils/loader.py
@@ -1,0 +1,26 @@
+"""Placeholder utilities for loading ASE demonstration data."""
+
+from typing import Generator, Tuple
+
+import torch
+
+
+class ASELoader:
+    """Minimal data loader for ASE expert demonstrations.
+
+    The loader yields dummy state transitions and is intended to be
+    replaced with a proper dataset handling implementation.
+    """
+
+    def __init__(self, obs_dim: int, device: str = "cpu") -> None:
+        self.obs_dim = obs_dim
+        self.device = torch.device(device)
+
+    def feed_forward_generator(
+        self, num_mini_batch: int, mini_batch_size: int
+    ) -> Generator[Tuple[torch.Tensor, torch.Tensor], None, None]:
+        """Yields batches of random (state, next_state) pairs."""
+        for _ in range(num_mini_batch):
+            state = torch.randn(mini_batch_size, self.obs_dim, device=self.device)
+            next_state = torch.randn(mini_batch_size, self.obs_dim, device=self.device)
+            yield state, next_state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,4 @@ Changelog = "https://github.com/ami-iit/amp-rsl-rl/releases"
 local_scheme = "dirty-tag"
 
 [tool.setuptools]
-packages = ["amp_rsl_rl"]
+packages = ["amp_rsl_rl", "ase_rsl_rl"]


### PR DESCRIPTION
## Summary
- add `ase_rsl_rl` package as scaffold for Adversarial Skill Embeddings
- implement `ASE_PPO` algorithm and placeholder skill-aware utilities
- document new ASE framework and include package in build configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bbd247a2848322a076bc42f3eca243